### PR TITLE
Add missing local TypeScript check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,11 @@ do-frontend-lint:
 	@echo "Starting frontend codestyle check.."
 	@docker-compose exec frontend sh -c "yarn lint"
 
+
+do-frontend-typescript:
+	@echo "Starting frontend TypeScript check.."
+	@docker-compose exec frontend sh -c "yarn typescript"
+
 do-shell-backend:
 	@docker-compose exec backend sh
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "npx cypress run",
-    "lint": "eslint '**/*.{ts,tsx}'"
+    "lint": "eslint '**/*.{ts,tsx}'",
+    "typescript": "tsc --noEmit"
   },
   "dependencies": {
     "gatsby": "^5.12.9",


### PR DESCRIPTION
### Context

(Re?)Adds missing local TypeScript check

### How to test

Clone repo and run `make build`

2. Run `make lint`
3. Verify that the command also ran the TypeScript check with `tsc`