### PR TITLE
Update dependabot to enable dev package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     - "/backend"
   schedule:
     interval: "weekly"
-  allow:
-    - dependency-type: "production"
   groups:
     sanity:
       applies-to: version-updates


### PR DESCRIPTION
In addition to keeping the production node_modules up to date, we're now enabling dev packages as well.

This was disabled before because of ESLint v8. Now we upgraded to v9 and are allowing dev package update PR's as well.