### PR TITLE
Add node_modules npm cache to actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,10 +7,12 @@ jobs:
       run:
         working-directory: ./frontend
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
       - name: Install modules
         run: yarn install
       - name: Run ESLint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: 20
           cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
+          cache-dependency-path: 'frontend/yarn.lock'
       - name: Install modules
         run: yarn install
       - name: Run ESLint

--- a/.github/workflows/sanity-deploy.yml
+++ b/.github/workflows/sanity-deploy.yml
@@ -9,7 +9,12 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
       - name: Install modules
         run: yarn install
       - name: Deploy Sanity

--- a/.github/workflows/sanity-deploy.yml
+++ b/.github/workflows/sanity-deploy.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 20
           cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
+          cache-dependency-path: 'backend/yarn.lock'
       - name: Install modules
         run: yarn install
       - name: Deploy Sanity

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
         with:
           node-version: 20
           cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
+          cache-dependency-path: 'frontend/yarn.lock'
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: 20
           cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
+          cache-dependency-path: 'backend/yarn.lock'
       - name: Install modules
         run: yarn install
       - name: Build Sanity Studio

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,12 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:
@@ -22,10 +24,12 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'yarn'
+          cache-dependency-path: 'yarn.lock'
       - name: Install modules
         run: yarn install
       - name: Build Sanity Studio


### PR DESCRIPTION
Adding node_modules npm cache to actions will speed up the GitHub Actions, installing node modules will be way faster.