### PR TITLE
Add yarn dedupe check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         run: corepack enable
       - name: Install modules
         run: yarn install --immutable
+      - name: Check dependencies that could be deduplicated
+        run: yarn dedupe --check
       - name: Run ESLint
         run: yarn lint
       - name: Build project & generate types


### PR DESCRIPTION
## What
Added a new CI step to check for duplicate dependencies using `yarn dedupe --check`.
When pipeline fails, run `yarn dedupe`.

## Why
Ensures that dependencies across workspaces are properly deduplicated, preventing bloated `node_modules` and potential version conflicts in the monorepo.

## Docs
https://yarnpkg.com/cli/dedupe