### PR TITLE
Add npmMinimalAgeGate: "3d"

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 enableGlobalCache: true
 
 nodeLinker: node-modules
+
+npmMinimalAgeGate: "3d"


### PR DESCRIPTION
Adds `npmMinimalAgeGate: "3d"` to `.yarnrc.yml` to prevent Yarn from installing packages published less than 3 days ago. This is a security measure to mitigate supply chain attacks via recently published (potentially malicious) packages.